### PR TITLE
Allows automated default groups assignment for users from 'Remote Directories'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.orange.jira</groupId>
 	<artifactId>jira-shibboleth.connector</artifactId>
-	<version>1.0.0</version>
+	<version>1.1.0</version>
 
 	<organization>
 		<name>Orange Business Services</name>
@@ -22,6 +22,14 @@
 			<version>${jira.version}</version>
 			<scope>provided</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>com.atlassian.jira</groupId>
+			<artifactId>jira-core</artifactId>
+			<version>${jira.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>com.atlassian.seraph</groupId>
 			<artifactId>atlassian-seraph</artifactId>
@@ -44,15 +52,15 @@
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 		</plugins>
 	</build>
 	<properties>
 		<jira.version>6.1.7</jira.version>
-		<amps.version>4.2.18</amps.version>
+		<amps.version>6.2.6</amps.version>
 	</properties>
 	<scm>
 		<url>http://git.si.mbs/si/jira-shibboleth-connector/tree/master</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.orange.jira</groupId>
 	<artifactId>jira-shibboleth.connector</artifactId>
-	<version>1.1.0</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<organization>
 		<name>Orange Business Services</name>
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>com.atlassian.seraph</groupId>
 			<artifactId>atlassian-seraph</artifactId>
-			<version>2.6.0</version>
+			<version>3.1.1</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>
@@ -59,7 +59,7 @@
 		</plugins>
 	</build>
 	<properties>
-		<jira.version>6.1.7</jira.version>
+		<jira.version>7.2.5</jira.version>
 		<amps.version>6.2.6</amps.version>
 	</properties>
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.orange.jira</groupId>
 	<artifactId>jira-shibboleth.connector</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.1.0</version>
 
 	<organization>
 		<name>Orange Business Services</name>

--- a/src/main/java/com/orange/jira/login/ShibbolethAuthenticator.java
+++ b/src/main/java/com/orange/jira/login/ShibbolethAuthenticator.java
@@ -1,29 +1,50 @@
 package com.orange.jira.login;
 
+import com.atlassian.crowd.directory.DelegatedAuthenticationDirectory;
+import com.atlassian.crowd.directory.RemoteDirectory;
+import com.atlassian.crowd.directory.loader.DirectoryInstanceLoader;
+import com.atlassian.crowd.embedded.api.Directory;
+import com.atlassian.crowd.exception.DirectoryNotFoundException;
+import com.atlassian.crowd.exception.FailedAuthenticationException;
+import com.atlassian.crowd.exception.UserNotFoundException;
+import com.atlassian.crowd.exception.runtime.CommunicationException;
+import com.atlassian.crowd.exception.runtime.OperationFailedException;
+import com.atlassian.crowd.manager.directory.DirectoryManager;
+import com.atlassian.jira.bc.security.login.LoginInfo;
+import com.atlassian.jira.bc.security.login.LoginService;
+import com.atlassian.jira.component.ComponentAccessor;
+import com.atlassian.jira.security.login.LoginStore;
+import com.atlassian.jira.user.ApplicationUser;
+import com.atlassian.seraph.auth.AuthenticationErrorType;
+import com.atlassian.seraph.auth.AuthenticatorException;
+import com.atlassian.seraph.auth.DefaultAuthenticator;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.security.Principal;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import com.atlassian.crowd.exception.FailedAuthenticationException;
-import com.atlassian.crowd.exception.runtime.CommunicationException;
-import com.atlassian.crowd.exception.runtime.OperationFailedException;
-import com.atlassian.jira.component.ComponentAccessor;
-import com.atlassian.seraph.auth.AuthenticationErrorType;
-import com.atlassian.seraph.auth.AuthenticatorException;
-import com.atlassian.seraph.auth.DefaultAuthenticator;
-
 public class ShibbolethAuthenticator extends DefaultAuthenticator {
+
+	private final Logger log = Logger.getLogger(ShibbolethAuthenticator.class);
 
 	@Override
 	public Principal getUser(HttpServletRequest request, HttpServletResponse response) {
+		String username = request.getRemoteUser();
 		if (!userIsAlreadyLogged(request) && !urlIsSkipped(request)) {
-			String username = request.getRemoteUser();
 			if (username != null) {
 				Principal user = getUser(username);
 				putPrincipalInSessionContext(request, user);
+			}
+		} else {
+			// User is already logged in. We check whether a connection has already been detected by JIRA.
+			if (this.isFirstLogin(request.getRemoteUser())) {
+				// If no login has been yet. It is either the very first connection of our user, or it is a SSO user
+				// for which login count is not updated. We try to update user details via the directory configuration.
+				tryToUpdateGroupMembership(username);
 			}
 		}
 		return (Principal) request.getSession().getAttribute(LOGGED_IN_KEY);
@@ -63,4 +84,55 @@ public class ShibbolethAuthenticator extends DefaultAuthenticator {
 
 	private final static long serialVersionUID = 1492747625496115491L;
 	private final static List<String> SKIPPED_URLS = Arrays.asList("security-tokens", "/Shibboleth.sso/Logout", "/logout");
+
+	private boolean isFirstLogin(String username) {
+		if (StringUtils.isEmpty(username)) {
+			return false;
+		}
+		LoginService loginService = ComponentAccessor.getComponentOfType(LoginService.class);
+		if (loginService != null) {
+			LoginInfo info = loginService.getLoginInfo(username);
+			if (log.isDebugEnabled() && info != null) {
+				log.debug("User " + username + " connection count is at : " + info.getLoginCount());
+			}
+			return info == null || info.getLoginCount() == null || info.getLoginCount() == 0;
+		} else {
+			log.error("LoginService is not available");
+		}
+
+		return false;
+	}
+
+	private void tryToUpdateGroupMembership(String username) {
+		ApplicationUser user = ComponentAccessor.getUserManager().getUserByName(username);
+		if (user != null) {
+			DirectoryManager directoryManager = ComponentAccessor.getComponentOfType(DirectoryManager.class);
+			if (directoryManager != null) {
+				try {
+					Directory directory = directoryManager.findDirectoryById(user.getDirectoryId());
+					DirectoryInstanceLoader directoryInstanceLoader =  ComponentAccessor.getComponentOfType(DirectoryInstanceLoader.class);
+					if (directoryInstanceLoader != null) {
+						RemoteDirectory remoteDirectory = directoryInstanceLoader.getDirectory(directory);
+						if (remoteDirectory instanceof DelegatedAuthenticationDirectory) {
+							((DelegatedAuthenticationDirectory) remoteDirectory).addOrUpdateLdapUser(username);
+							// Finally we record a successful login so as to update the groups only once per user.
+							LoginStore loginStore = ComponentAccessor.getComponentOfType(LoginStore.class);
+							loginStore.recordLoginAttempt(user.getDirectoryUser(), true);
+						}
+					}
+				} catch (DirectoryNotFoundException e) {
+					log.error("Directory with ID " + user.getDirectoryId() + " has not been found"); // Should not happen since user is supposed to be already logged in
+				} catch (UserNotFoundException e) {
+					// Should not happen. ALl checks have been made previously
+					log.error("UserNotFoundException detected !", e); // Should not happen since user is supposed to be already logged in
+				} catch (com.atlassian.crowd.exception.OperationFailedException e) {
+					log.warn("Could not update user details for " + username, e);
+				}
+			} else {
+				log.error("Directory Manager is not available : we cannot proceed with group assignment");
+			}
+		} else {
+			log.warn("Unable to find user for name : " + username + " eventhough he is already logged in !");
+		}
+	}
 }

--- a/src/main/java/com/orange/jira/login/ShibbolethAuthenticator.java
+++ b/src/main/java/com/orange/jira/login/ShibbolethAuthenticator.java
@@ -109,44 +109,27 @@ public class ShibbolethAuthenticator extends DefaultAuthenticator {
 
 	private void tryToUpdateGroupMembership(String username) {
 		boolean dbg = log.isDebugEnabled();
-		boolean trace = log.isTraceEnabled();
 		ApplicationUser user = ComponentAccessor.getUserManager().getUserByName(username);
 		if (user != null) {
-			if (trace) {
-				log.trace("user has been found");
-			}
 			DirectoryManager directoryManager = ComponentAccessor.getComponentOfType(DirectoryManager.class);
 			if (directoryManager != null) {
-				if (trace) {
-					log.trace("Directory manager has been acquired");
-				}
 				try {
 					Directory directory = directoryManager.findDirectoryById(user.getDirectoryId());
 					if (directory != null) {
-						if (trace) {
-							log.trace("Directory has been found");
-						}
 						String groups = (directory.getAttributes() != null) ? directory.getAttributes().get("autoAddGroups") : null;
 						if (dbg) {
-							log.trace("Auto add Groups for the directory are : " + groups != null ? groups : "null");
+							log.debug("Auto add Groups for the directory are : " + groups != null ? groups : "null");
 						}
 						if (groups != null) {
 							for (String groupName : groups.split("\\|")) {
 								Group group = ComponentAccessor.getGroupManager().getGroup(groupName);
 								if (group != null) {
-									if (trace) {
-										log.trace("Group " + groupName + " does exist");
-									}
 									try {
 										ComponentAccessor.getGroupManager().addUserToGroup(user, group);
 									} catch (GroupNotFoundException e) {
 										log.error(e);
 									} catch (OperationNotPermittedException e) {
 										log.error(e);
-									}
-								} else {
-									if (trace) {
-										log.trace("Group " + groupName + " does NOT exist");
 									}
 								}
 							}


### PR DESCRIPTION
Default groups assignment is done only once per user. When a user is detected as coming from a remote repository (LDAP, Microsoft AD, etc.) JIRA should not have stored the login count for the user. We rely on this data (loss) to evaluate whether we should try to update the groups for a user and update the counter at the end so as not to repeat the process twice.